### PR TITLE
Fixes `mikepb/react-draggable#2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,6 @@
     "test": "script/test --single-run",
     "start": "script/build"
   },
-  "browserify": {
-    "transform": [
-      "reactify"
-    ]
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mikepb/react-draggable.git"
@@ -33,6 +28,9 @@
     "url": "https://github.com/mikepb/react-draggable/issues"
   },
   "homepage": "https://github.com/mikepb/react-draggable",
+  "dependencies": {
+    "react": "^0.12.2"
+  },
   "devDependencies": {
     "jsx-loader": "^0.12.2",
     "karma": "^0.12.31",
@@ -40,7 +38,6 @@
     "karma-cli": "^0.0.4",
     "karma-jasmine": "^0.3.5",
     "karma-webpack": "^1.5.0",
-    "react": "^0.12.2",
     "uglify-js": "^2.4.16",
     "webpack": "^1.6.0",
     "webpack-dev-server": "^1.6.6"


### PR DESCRIPTION
See: mikepb/react-draggable#2

The previous `package.json` applied a global Browserify transform
without requiring it as a production dependency. This caused Browserify
bundling to fail unless it was installed elsewhere. The use of `require`
was also broken, because `react` was not a production dependency. This
just fixes these minor configuration issues by removing the transform
and making `react` a production dependency.