### PR TITLE
Fix #5 and add tests for touch functionality

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -366,10 +366,13 @@ module.exports = React.createClass({
     onStop: React.PropTypes.func,
 
     /**
-     * A workaround option which can be passed if onMouseDown needs to be accessed, since it'll always be blocked (due to that there's internal use of onMouseDown)
+     * A workaround option which can be passed if these event handlers need to be accessed, since they're always handled internally.
      *
      */
-    onMouseDown: React.PropTypes.func
+    onMouseDown: React.PropTypes.func,
+    onTouchStart: React.PropTypes.func,
+    onMouseUp: React.PropTypes.func,
+    onTouchEnd: React.PropTypes.func,
   },
 
   componentWillMount: function() {
@@ -392,7 +395,10 @@ module.exports = React.createClass({
       onStart: emptyFunction,
       onDrag: emptyFunction,
       onStop: emptyFunction,
-      onMouseDown: emptyFunction
+      onMouseDown: emptyFunction,
+      onMouseUp: emptyFunction,
+      onTouchStart: emptyFunction,
+      onTouchEnd: emptyFunction,
     };
   },
 
@@ -436,28 +442,39 @@ module.exports = React.createClass({
   },
 
   handleMouseDown: function(e) {
-    return this.handleDragStart(e, 'mouse');
+    if (typeof this.props.onMouseDown === 'function')
+      this.props.onMouseDown(e);
+    if (!e.defaultPrevented)    
+      this.handleDragStart(e, 'mouse');
   },
 
   handleMouseMove: function(e) {
-    return this.handleDrag(e, 'mouse');
+    this.handleDrag(e, 'mouse');
   },
 
   handleMouseUp: function(e) {
-    return this.handleDragEnd(e, 'mouse');
+    if (typeof this.props.onMouseUp === 'function')
+      this.props.onMouseUp(e);
+    if (!e.defaultPrevented)  
+      this.handleDragEnd(e, 'mouse');
   },
 
   handleTouchStart: function(e) {
-    e.preventDefault(); // prevent for scroll
-    return this.handleDragStart(e, 'touch');
+    if (typeof this.props.onTouchStart === 'function')
+      this.props.onTouchStart(e);    
+    if (!e.defaultPrevented)
+      this.handleDragStart(e, 'touch');
   },
 
   handleTouchMove: function(e) {
-    return this.handleDrag(e, 'touch');    
+    this.handleDrag(e, 'touch');    
   },
 
   handleTouchEnd: function(e) {
-    return this.handleDragEnd(e, 'touch');
+    if (typeof this.props.onTouchEnd === 'function')
+      this.props.onTouchEnd(e);
+    if (!e.defaultPrevented)
+      this.handleDragEnd(e, 'touch');
   },
   
   handleDragStart: function (e, device) {
@@ -471,14 +488,13 @@ module.exports = React.createClass({
     //     return
     // }
 
-    // Make it possible to attach event handlers on top of this one
-    this.props.onMouseDown(e);
-
     // Short circuit if handle or cancel prop was provided and selector doesn't match
     if ((this.props.handle && !matchesSelector(e.target, this.props.handle)) ||
       (this.props.cancel && matchesSelector(e.target, this.props.cancel))) {
       return;
     }
+
+    e.preventDefault();
 
     var dragPoint = getControlPosition(e);
 
@@ -507,6 +523,8 @@ module.exports = React.createClass({
     if (!this.state.dragging || (this.state.dragging !== device)) {
       return;
     }
+
+    e.preventDefault();
 
     // Turn off dragging
     this.setState({
@@ -662,7 +680,6 @@ module.exports = React.createClass({
 
       onMouseDown: this._dragHandlers.mouse.start,
       onTouchStart: this._dragHandlers.touch.start,
-
       onMouseUp: this._dragHandlers.mouse.end,
       onTouchEnd: this._dragHandlers.touch.end,
     };

--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -3,13 +3,6 @@
 var React = require('react/addons');
 var emptyFunction = function () {};
 
-// for accessing browser globals
-var root = typeof window !== 'undefined' ? window : this;
-var bodyElement;
-if (typeof document !== 'undefined' && 'body' in document) {
-  bodyElement = document.body;
-}
-
 function updateBoundState (state, bound) {
   if (!bound) return state;
   bound = String(bound);
@@ -72,10 +65,6 @@ function matchesSelector(el, selector) {
   return el[method].call(el, selector);
 }
 
-// @credits: http://stackoverflow.com/questions/4817029/whats-the-best-way-to-detect-a-touch-screen-device-using-javascript/4819886#4819886
-var isTouchDevice = 'ontouchstart' in root // works on most browsers
-                 || 'onmsgesturechange' in root; // works on ie10 on ms surface
-
 // look ::handleDragStart
 //function isMultiTouch(e) {
 //  return e.touches && Array.isArray(e.touches) && e.touches.length > 1
@@ -84,21 +73,18 @@ var isTouchDevice = 'ontouchstart' in root // works on most browsers
 /**
  * simple abstraction for dragging events names
  * */
-var dragEventFor = (function () {
-  var eventsFor = {
-    touch: {
-      start: 'touchstart',
-      move: 'touchmove',
-      end: 'touchend'
-    },
-    mouse: {
-      start: 'mousedown',
-      move: 'mousemove',
-      end: 'mouseup'
-    }
-  };
-  return eventsFor[isTouchDevice ? 'touch' : 'mouse'];
-})();
+ var dragEventsFor = {
+  touch: {
+    start: 'touchstart',
+    move: 'touchmove',
+    end: 'touchend'
+  },
+  mouse: {
+    start: 'mousedown',
+    move: 'mousemove',
+    end: 'mouseup'
+  }
+};
 
 /**
  * get {clientX, clientY} positions of control
@@ -386,6 +372,13 @@ module.exports = React.createClass({
     onMouseDown: React.PropTypes.func
   },
 
+  componentWillMount: function() {
+    this._dragHandlers = {
+      mouse: {start: this.handleMouseDown, move: this.handleMouseMove, end: this.handleMouseUp},
+      touch: {start: this.handleTouchStart, move: this.handleTouchMove, end: this.handleTouchEnd}
+    };
+  },
+
   getDefaultProps: function () {
     return {
       axis: 'both',
@@ -435,11 +428,42 @@ module.exports = React.createClass({
 
   componentWillUnmount: function() {
     // Remove any leftover event handlers
-    removeEvent(bodyElement, dragEventFor['move'], this.handleDrag);
-    removeEvent(bodyElement, dragEventFor['end'], this.handleDragEnd);
+    var bodyElement = this.getDOMNode().ownerDocument.body;
+    removeEvent(bodyElement, dragEventsFor.mouse.move, this._dragHandlers.mouse.move);
+    removeEvent(bodyElement, dragEventsFor.mouse.end,  this._dragHandlers.mouse.end);
+    removeEvent(bodyElement, dragEventsFor.touch.move, this._dragHandlers.touch.move);
+    removeEvent(bodyElement, dragEventsFor.touch.end,  this._dragHandlers.touch.end);
   },
 
-  handleDragStart: function (e) {
+  handleMouseDown: function(e) {
+    return this.handleDragStart(e, 'mouse');
+  },
+
+  handleMouseMove: function(e) {
+    return this.handleDrag(e, 'mouse');
+  },
+
+  handleMouseUp: function(e) {
+    return this.handleDragEnd(e, 'mouse');
+  },
+
+  handleTouchStart: function(e) {
+    e.preventDefault(); // prevent for scroll
+    return this.handleDragStart(e, 'touch');
+  },
+
+  handleTouchMove: function(e) {
+    return this.handleDrag(e, 'touch');    
+  },
+
+  handleTouchEnd: function(e) {
+    return this.handleDragEnd(e, 'touch');
+  },
+  
+  handleDragStart: function (e, device) {
+    if (this.state.dragging)
+      return;
+
     // todo: write right implementation to prevent multitouch drag
     // prevent multi-touch events
     // if (isMultiTouch(e)) {
@@ -460,7 +484,7 @@ module.exports = React.createClass({
 
     // Initiate dragging
     this.setState({
-      dragging: true,
+      dragging: device,
       clientX: dragPoint.clientX,
       clientY: dragPoint.clientY
     });
@@ -468,17 +492,19 @@ module.exports = React.createClass({
     // Call event handler
     this.props.onStart(e, createUIEvent(this));
 
+    var bodyElement = this.getDOMNode().ownerDocument.body;
+
     // Add event handlers
-    addEvent(bodyElement, dragEventFor['move'], this.handleDrag);
-    addEvent(bodyElement, dragEventFor['end'], this.handleDragEnd);
+    addEvent(bodyElement, dragEventsFor[device].move, this._dragHandlers[device].move);
+    addEvent(bodyElement, dragEventsFor[device].end, this._dragHandlers[device].end);
 
     // Add dragging class to body element
     if (bodyElement) bodyElement.className += ' react-draggable-dragging';
   },
 
-  handleDragEnd: function (e) {
+  handleDragEnd: function (e, device) {
     // Short circuit if not currently dragging
-    if (!this.state.dragging) {
+    if (!this.state.dragging || (this.state.dragging !== device)) {
       return;
     }
 
@@ -490,9 +516,13 @@ module.exports = React.createClass({
     // Call event handler
     this.props.onStop(e, createUIEvent(this));
 
+    
+    var bodyElement = this.getDOMNode().ownerDocument.body;
+
     // Remove event handlers
-    removeEvent(root, dragEventFor['move'], this.handleDrag);
-    removeEvent(root, dragEventFor['end'], this.handleDragEnd);
+    removeEvent(bodyElement, dragEventsFor[device].move, this._dragHandlers[device].move);
+    removeEvent(bodyElement, dragEventsFor[device].end, this._dragHandlers[device].end);
+
 
     // Remove dragging class from body element
     if (bodyElement) {
@@ -502,7 +532,7 @@ module.exports = React.createClass({
     }
   },
 
-  handleDrag: function (e) {
+  handleDrag: function (e, device) {
     var dragPoint = getControlPosition(e);
     var offsetLeft = this._toPixels(this.state.offsetLeft);
     var offsetTop = this._toPixels(this.state.offsetTop);
@@ -615,11 +645,6 @@ module.exports = React.createClass({
     this.props.onDrag(e, createUIEvent(this));
   },
 
-  onTouchStart: function (e) {
-    e.preventDefault(); // prevent for scroll
-    return this.handleDragStart.apply(this, arguments);
-  },
-
   render: function () {
     var style = {
       top: this.state.offsetTop,
@@ -635,11 +660,11 @@ module.exports = React.createClass({
       style: style,
       className: 'react-draggable',
 
-      onMouseDown: this.handleDragStart,
-      onTouchStart: this.onTouchStart,
+      onMouseDown: this._dragHandlers.mouse.start,
+      onTouchStart: this._dragHandlers.touch.start,
 
-      onMouseUp: this.handleDragEnd,
-      onTouchEnd: this.handleDragEnd
+      onMouseUp: this._dragHandlers.mouse.end,
+      onTouchEnd: this._dragHandlers.touch.end,
     };
 
     // Reuse the child provided

--- a/lib/styles.css
+++ b/lib/styles.css
@@ -1,4 +1,4 @@
-.react-draggable, .react-draggable-dragging {
+.react-draggable strong, .react-draggable-dragging strong {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/test/draggable_test.jsx
+++ b/test/draggable_test.jsx
@@ -259,4 +259,60 @@ describe('react-draggable', function () {
 			expect(error).toEqual(true);
 		});
 	});
+
+	describe('mouse events', function () {
+		it('should pass through onMouseDown', function () {
+			var called = false;
+
+			var drag = TestUtils.renderIntoDocument(<Draggable onMouseDown={function() {called = true;}}><div/></Draggable>);
+
+			TestUtils.Simulate.mouseDown(drag.getDOMNode());
+			expect(called).toEqual(true);
+		});
+
+		it('should not drag if onMouseDown calls preventDefault', function () {
+			var drag = TestUtils.renderIntoDocument(<Draggable onMouseDown={function(e) {e.preventDefault();}}><div/></Draggable>);
+
+			TestUtils.Simulate.mouseDown(drag.getDOMNode());
+			expect(drag.state.dragging).toEqual(false);
+		});
+
+		it('should pass through onMouseUp', function () {
+			var called = false;
+
+			var drag = TestUtils.renderIntoDocument(<Draggable onMouseUp={function() {called = true;}}><div/></Draggable>);
+
+			TestUtils.Simulate.mouseUp(drag.getDOMNode());
+			expect(called).toEqual(true);
+		});
+	});
+
+	describe('touch events', function() {
+		it('should pass through onTouchStart', function () {
+			var called = false;
+
+			var drag = TestUtils.renderIntoDocument(<Draggable onTouchStart={function() {called = true;}}><div/></Draggable>);
+
+			TestUtils.Simulate.touchStart(drag.getDOMNode());
+			expect(called).toEqual(true);
+		});
+
+		it('should not drag if onTouchStart calls preventDefault', function () {
+			var drag = TestUtils.renderIntoDocument(<Draggable onTouchStart={function(e) {e.preventDefault();}}><div/></Draggable>);
+
+			TestUtils.Simulate.touchStart(drag.getDOMNode());
+			expect(drag.state.dragging).toEqual(false);
+		});
+
+
+		it('should pass through onTouchEnd', function () {
+			var called = false;
+
+			var drag = TestUtils.renderIntoDocument(<Draggable onTouchEnd={function() {called = true;}}><div/></Draggable>);
+
+			TestUtils.Simulate.touchEnd(drag.getDOMNode());
+			expect(called).toEqual(true);
+		});
+	});
+
 });

--- a/test/draggable_test.jsx
+++ b/test/draggable_test.jsx
@@ -2,6 +2,7 @@
 var React = require('react/addons');
 var TestUtils = React.addons.TestUtils;
 var Draggable = require('../lib/draggable');
+React.initializeTouchEvents(true);
 
 describe('react-draggable', function () {
 	describe('props', function () {
@@ -86,6 +87,32 @@ describe('react-draggable', function () {
 			expect(called).toEqual(true);
 		});
 
+		it('should call onStart when touch dragging begins', function () {
+			var called = false;
+			var drag = TestUtils.renderIntoDocument(
+				<Draggable onStart={function () { called = true; }}>
+					<div/>
+				</Draggable>
+			);
+
+			TestUtils.Simulate.touchStart(drag.getDOMNode());
+			expect(called).toEqual(true);
+		});
+
+		it('should call onStop when touch dragging ends', function () {
+			var called = false;
+			var drag = TestUtils.renderIntoDocument(
+				<Draggable onStop={function () { called = true; }}>
+					<div/>
+				</Draggable>
+			);
+
+			TestUtils.Simulate.touchStart(drag.getDOMNode());
+			TestUtils.Simulate.touchEnd(drag.getDOMNode());
+			expect(called).toEqual(true);
+		});
+
+
 		it('should add react-draggable-dragging CSS class to body element when dragging', function () {
 			var drag = TestUtils.renderIntoDocument(
 				<Draggable>
@@ -99,12 +126,12 @@ describe('react-draggable', function () {
 		});
 	});
 
-	describe('interaction', function () {
+	describe('mouse interaction', function () {
 		it('should initialize dragging onmousedown', function () {
 			var drag = TestUtils.renderIntoDocument(<Draggable><div/></Draggable>);
 
 			TestUtils.Simulate.mouseDown(drag.getDOMNode());
-			expect(drag.state.dragging).toEqual(true);
+			expect(drag.state.dragging).toEqual('mouse');
 		});
 
 		it('should only initialize dragging onmousedown of handle', function () {
@@ -121,7 +148,7 @@ describe('react-draggable', function () {
 			expect(drag.state.dragging).toEqual(false);
 
 			TestUtils.Simulate.mouseDown(drag.getDOMNode().querySelector('.handle'));
-			expect(drag.state.dragging).toEqual(true);
+			expect(drag.state.dragging).toEqual('mouse');
 		});
 
 		it('should not initialize dragging onmousedown of cancel', function () {
@@ -138,18 +165,71 @@ describe('react-draggable', function () {
 			expect(drag.state.dragging).toEqual(false);
 
 			TestUtils.Simulate.mouseDown(drag.getDOMNode().querySelector('.content'));
-			expect(drag.state.dragging).toEqual(true);
+			expect(drag.state.dragging).toEqual('mouse');
 		});
 
 		it('should discontinue dragging onmouseup', function () {
 			var drag = TestUtils.renderIntoDocument(<Draggable><div/></Draggable>);
 
 			TestUtils.Simulate.mouseDown(drag.getDOMNode());
-			expect(drag.state.dragging).toEqual(true);
+			expect(drag.state.dragging).toEqual('mouse');
 
 			TestUtils.Simulate.mouseUp(drag.getDOMNode());
 			expect(drag.state.dragging).toEqual(false);
 		});
+	});
+	
+	describe('touch interaction', function () {
+		it('should initialize dragging ontouchstart', function () {
+			var drag = TestUtils.renderIntoDocument(<Draggable><div/></Draggable>);
+
+			TestUtils.Simulate.touchStart(drag.getDOMNode());
+			expect(drag.state.dragging).toEqual('touch');
+		});
+
+		it('should only initialize dragging ontouchstart of handle', function () {
+			var drag = TestUtils.renderIntoDocument(
+				<Draggable handle=".handle">
+					<div>
+						<div className="handle">Handle</div>
+						<div className="content">Lorem ipsum...</div>
+					</div>
+				</Draggable>
+			);
+
+			TestUtils.Simulate.touchStart(drag.getDOMNode().querySelector('.content'));
+			expect(drag.state.dragging).toEqual(false);
+
+			TestUtils.Simulate.touchStart(drag.getDOMNode().querySelector('.handle'));
+			expect(drag.state.dragging).toEqual('touch');
+		});
+
+		it('should not initialize dragging ontouchstart of cancel', function () {
+			var drag = TestUtils.renderIntoDocument(
+				<Draggable cancel=".cancel">
+					<div>
+						<div className="cancel">Cancel</div>
+						<div className="content">Lorem ipsum...</div>
+					</div>
+				</Draggable>
+			);
+
+			TestUtils.Simulate.touchStart(drag.getDOMNode().querySelector('.cancel'));
+			expect(drag.state.dragging).toEqual(false);
+
+			TestUtils.Simulate.touchStart(drag.getDOMNode().querySelector('.content'));
+			expect(drag.state.dragging).toEqual('touch');
+		});
+
+		it('should discontinue dragging ontouchend', function () {
+			var drag = TestUtils.renderIntoDocument(<Draggable><div/></Draggable>);
+
+			TestUtils.Simulate.touchStart(drag.getDOMNode());
+			expect(drag.state.dragging).toEqual('touch');
+
+			TestUtils.Simulate.touchEnd(drag.getDOMNode());
+			expect(drag.state.dragging).toEqual(false);
+		});		
 	});
 
 	describe('validation', function () {


### PR DESCRIPTION
In this PR, I have:
* Removed the globals `root` and `bodyElement` in favor of always setting and clearing events on `this.getDOMNode().ownerDocument.body`.
* Removed `isTouchDevice` and the either/or relationship between touch and mouse events in favor of tracking the source device on a per-drag basis. This tracking relies on having separate handlers for touch and mouse events; For the record, my earlier approach of just inspecting `event.type` in the shared handlers did not pan out, because `TestUtils.Simulate` doesn't seem to set that property.
* Removed `dragEventFor` in favor of `dragEventsFor.mouse` and `dragEventsFor.touch`.
* Changed the semantics of `state.dragging` slightly - its value is now always one of  `false`, `'touch'` and `'mouse'`. This is mainly so that a stray `mouseup` doesn't interfere with an ongoing touch-based drag operation, and vice versa.
* Added tests that use simulated touch events alongside the existing ones for mouse events. (All tests pass on my machine, but please see #7)