### PR TITLE
Update example to use constrain function

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ var App = React.createClass({
 			<Draggable
 				axis="x"
 				handle=".handle"
-				grid={constrain(25)}
+				constrain={constrain(25)}
 				start={{x: 25, y: 25}}
 				bound="all box"
 				zIndex={100}


### PR DESCRIPTION
It looks like 41c7092221b4c7d8ff89a88c85932f0f400eefa0 should have changed `grid` to `constrain`.